### PR TITLE
親カテゴリ追加

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/db/migrate/20200508004448_create_categories.rb
+++ b/db/migrate/20200508004448_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_05_08_004448) do
+
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,13 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Category.create(name: "レディース")
+Category.create(name: "メンズ")
+Category.create(name: "ベビー・キッズ")
+Category.create(name: "インテリア・住まい・小物")
+Category.create(name: "本・音楽・ゲーム")
+Category.create(name: "おもちゃ・ホビー・グッズ")
+Category.create(name: "コスメ・香水・美容")
+Category.create(name: "家電・スマホ・カメラ")
+Category.create(name: "スポーツ・レジャー")
+Category.create(name: "ハンドメイド")
+Category.create(name: "チケット")
+Category.create(name: "自動車・オートバイ")
+Category.create(name: "その他")

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
カテゴリデータの追加。
※出品ページ作成のため、最低限データを保存するために必要な親カテゴリの情報のみ追加してます。子・孫カテゴリに関しては後日実装予定。

# Why
商品を分類するために必須の機能のため。