### PR TITLE
PayJPを用いたクレジットカード購入機能の実装

### DIFF
--- a/app/assets/javascripts/card.js
+++ b/app/assets/javascripts/card.js
@@ -1,36 +1,36 @@
-// document.addEventListener(
-//   "DOMContentLoaded", e => {
+document.addEventListener(
+  "DOMContentLoaded", e => {
 
-//     if (document.getElementById("token_submit") != null) { 
-//       Payjp.setPublicKey("pk_test_3ec52b536b224b110b5fd750"); 
-//       let btn = document.getElementById("token_submit"); 
-//       btn.addEventListener("click", e => { 
-//         e.preventDefault(); /
-//         let card = {
-//           number: document.getElementById("card_number").value,
-//           cvc: document.getElementById("cvc").value,
-//           exp_month: document.getElementById("exp_month").value,
-//           exp_year: document.getElementById("exp_year").value
-//         };
+    if (document.getElementById("token_submit") != null) { 
+      Payjp.setPublicKey("pk_test_3ec52b536b224b110b5fd750"); 
+      let btn = document.getElementById("token_submit"); 
+      btn.addEventListener("click", e => { 
+        e.preventDefault(); /
+        let card = {
+          number: document.getElementById("card_number").value,
+          cvc: document.getElementById("cvc").value,
+          exp_month: document.getElementById("exp_month").value,
+          exp_year: document.getElementById("exp_year").value
+        };
 
-//         Payjp.createToken(card, (status, response) => {
-//           if (status === 200) { 
-//             $("#card_number").removeAttr("name");
-//             $("#cvc").removeAttr("name");
-//             $("#exp_month").removeAttr("name");
-//             $("#exp_year").removeAttr("name"); 
-//             $("#card_token").append(
-//               $('<input type="hidden" name="payjp_token">').val(response.id)
-//             ); 
-//             document.inputForm.submit();
-//             alert("クレジットカードの登録が完了しました。"); 
-//           } else {
-//             debugger
-//             alert("入力された情報が正しくありません。再度お試しください。"); 
-//           }
-//         });
-//       });
-//     }
-//   },
-//   false
-// );
+        Payjp.createToken(card, (status, response) => {
+          if (status === 200) { 
+            $("#card_number").removeAttr("name");
+            $("#cvc").removeAttr("name");
+            $("#exp_month").removeAttr("name");
+            $("#exp_year").removeAttr("name"); 
+            $("#card_token").append(
+              $('<input type="hidden" name="payjp_token">').val(response.id)
+            ); 
+            document.inputForm.submit();
+            alert("クレジットカードの登録が完了しました。"); 
+          } else {
+            debugger
+            alert("入力された情報が正しくありません。再度お試しください。"); 
+          }
+        });
+      });
+    }
+  },
+  false
+);

--- a/app/assets/javascripts/card.js
+++ b/app/assets/javascripts/card.js
@@ -5,7 +5,7 @@ document.addEventListener(
       Payjp.setPublicKey("pk_test_3ec52b536b224b110b5fd750"); 
       let btn = document.getElementById("token_submit"); 
       btn.addEventListener("click", e => { 
-        e.preventDefault(); /
+        e.preventDefault(); 
         let card = {
           number: document.getElementById("card_number").value,
           cvc: document.getElementById("cvc").value,

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,92 +1,92 @@
-# class CardsController < ApplicationController
-#   require "payjp"
+class CardsController < ApplicationController
+  require "payjp"
 
-#   before_action :get_payjp_info
-#   before_action :set_product, only: [:create, :show, :pay, :new]
-#   before_action :set_cards, only: [:delete, :index, :show, :new]
+  before_action :get_payjp_info
+  before_action :set_product, only: [:create, :show, :pay, :new]
+  before_action :set_cards, only: [:delete, :index, :show, :new]
 
-#   def set_cards
-#     @card = Card.find_by(user_id: current_user.id)
-#     @cards = Card.where(user_id: current_user.id)
+  def set_cards
+    @card = Card.find_by(user_id: current_user.id)
+    @cards = Card.where(user_id: current_user.id)
     
-#     @cnt = 0
-#     unless @card == nil
-#       @default_card_information = Payjp::Customer.retrieve(@card.customer_id).cards.data[0]
-#       @cards.each do |card|
-#         @cnt = @cnt + 1
-#         if @cnt == 1 
-#           @default_card_information1 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
-#         elsif @cnt == 2
-#           @default_card_information2 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
-#         elsif @cnt == 3
-#           @default_card_information3 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
-#         end
-#       end
-#     end
-#   end
+    @cnt = 0
+    unless @card == nil
+      @default_card_information = Payjp::Customer.retrieve(@card.customer_id).cards.data[0]
+      @cards.each do |card|
+        @cnt = @cnt + 1
+        if @cnt == 1 
+          @default_card_information1 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
+        elsif @cnt == 2
+          @default_card_information2 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
+        elsif @cnt == 3
+          @default_card_information3 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
+        end
+      end
+    end
+  end
 
-#   def set_product
-#     @product = Product.find(params[:product_id])
-#   end
+  def set_product
+    @product = Product.find(params[:product_id])
+  end
 
-#   def pay
-#     @parents = Category.where(ancestry: nil)  
-#     @card = Card.find_by(user_id: current_user.id)
-#     @product.buyer_user_id = current_user.id
-#     @product.save!
-#     @charge = Payjp::Charge.create(
-#     amount: @product.price,
-#     customer: @card.customer_id,
-#     currency: 'jpy'
-#       )
-#   end
+  def pay
+    @parents = Category.where(ancestry: nil)  
+    @card = Card.find_by(user_id: current_user.id)
+    @product.buyer_user_id = current_user.id
+    @product.save!
+    @charge = Payjp::Charge.create(
+    amount: @product.price,
+    customer: @card.customer_id,
+    currency: 'jpy'
+      )
+  end
 
-#   def create 
-#     customer = Payjp::Customer.create(
-#       card: params['payjp_token'],
-#       metadata: {user_id: current_user.id}
-#       ) 
-#     @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+  def create 
+    customer = Payjp::Customer.create(
+      card: params['payjp_token'],
+      metadata: {user_id: current_user.id}
+      ) 
+    @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
     
-#     if @card.save
-#       redirect_to action: "show"
-#       flash[:notice] = 'クレジットカードの登録が完了しました'
-#     else
-#       redirect_to action: "new"
-#       flash[:alert] = 'クレジットカード登録に失敗しました'
-#     end
-#   end
+    if @card.save
+      redirect_to action: "show"
+      flash[:notice] = 'クレジットカードの登録が完了しました'
+    else
+      redirect_to action: "new"
+      flash[:alert] = 'クレジットカード登録に失敗しました'
+    end
+  end
 
-#   def delete1
-#     cards = Card.where(user_id: current_user.id)
-#     card =cards[0]    
-#     customer = Payjp::Customer.retrieve(card.customer_id)
-#     customer.delete
-#     card.delete
-#     redirect_to  user_cards_path(current_user.id)
-#   end
+  def delete1
+    cards = Card.where(user_id: current_user.id)
+    card =cards[0]    
+    customer = Payjp::Customer.retrieve(card.customer_id)
+    customer.delete
+    card.delete
+    redirect_to  user_cards_path(current_user.id)
+  end
 
-#   def delete2
-#     cards = Card.where(user_id: current_user.id)
-#     card =cards[1]    
-#     customer = Payjp::Customer.retrieve(card.customer_id)
-#     customer.delete
-#     card.delete
-#     redirect_to  user_cards_path(current_user.id)
-#   end
+  def delete2
+    cards = Card.where(user_id: current_user.id)
+    card =cards[1]    
+    customer = Payjp::Customer.retrieve(card.customer_id)
+    customer.delete
+    card.delete
+    redirect_to  user_cards_path(current_user.id)
+  end
 
-#   def delete3
-#     cards = Card.where(user_id: current_user.id)
-#     card =cards[2]    
-#     customer = Payjp::Customer.retrieve(card.customer_id)
-#     customer.delete
-#     card.delete
-#     redirect_to  user_cards_path(current_user.id)
-#   end
+  def delete3
+    cards = Card.where(user_id: current_user.id)
+    card =cards[2]    
+    customer = Payjp::Customer.retrieve(card.customer_id)
+    customer.delete
+    card.delete
+    redirect_to  user_cards_path(current_user.id)
+  end
 
-#   private
+  private
 
-#   def get_payjp_info
-#     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_PRIVATE_KEY)
-#   end
-# end
+  def get_payjp_info
+    Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_PRIVATE_KEY)
+  end
+end

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -1,56 +1,56 @@
--# %body.card-index
--#   %h1.sub-header
--#     = link_to root_path do
--#       = image_tag "/images/logo/logo.png", class: "sub-header__logo"
+%body.card-index
+  %h1.sub-header
+    = link_to root_path do
+      = image_tag "/images/logo/logo.png", class: "sub-header__logo"
 
--#   %section.main-index
--#     %h2.main-index__title
--#       クレジットカード一覧
+  %section.main-index
+    %h2.main-index__title
+      クレジットカード一覧
 
--#     - if @cnt >= 1
--#       %h3.purchase-method__how
--#         .purchase-method__how--name
--#           ①クレジットカード
--#           = link_to delete1_user_cards_path(current_user.id), method: "post", class:"blue" do
--#             削除
--#         .purchase-method__how--number
--#           = "**** **** **** " + "#{@default_card_information1.last4}"
--#         .purchase-method__how--exp
--#           = "有効期限"  + "#{@default_card_information1.exp_month}"+"/" "#{@default_card_information1.exp_year}"
--#         .purchase-method__how--logo
--#           = icon('fas', 'credit-card')
--#           = @default_card_information1.brand
+    - if @cnt >= 1
+      %h3.purchase-method__how
+        .purchase-method__how--name
+          ①クレジットカード
+          = link_to delete1_user_cards_path(current_user.id), method: "post", class:"blue" do
+            削除
+        .purchase-method__how--number
+          = "**** **** **** " + "#{@default_card_information1.last4}"
+        .purchase-method__how--exp
+          = "有効期限"  + "#{@default_card_information1.exp_month}"+"/" "#{@default_card_information1.exp_year}"
+        .purchase-method__how--logo
+          = icon('fas', 'credit-card')
+          = @default_card_information1.brand
 
--#     - if @cnt >= 2
--#       %h3.purchase-method__how
--#         .purchase-method__how--name
--#           ②クレジットカード
--#           = link_to delete2_user_cards_path(current_user.id), method: "post", class:"blue" do
--#             削除
--#         .purchase-method__how--number
--#           = "**** **** **** " + "#{@default_card_information2.last4}"
--#         .purchase-method__how--exp
--#           = "有効期限"  + "#{@default_card_information2.exp_month}"+"/" "#{@default_card_information2.exp_year}"
--#         .purchase-method__how--logo
--#           = icon('fas', 'credit-card')
--#           = @default_card_information2.brand
+    - if @cnt >= 2
+      %h3.purchase-method__how
+        .purchase-method__how--name
+          ②クレジットカード
+          = link_to delete2_user_cards_path(current_user.id), method: "post", class:"blue" do
+            削除
+        .purchase-method__how--number
+          = "**** **** **** " + "#{@default_card_information2.last4}"
+        .purchase-method__how--exp
+          = "有効期限"  + "#{@default_card_information2.exp_month}"+"/" "#{@default_card_information2.exp_year}"
+        .purchase-method__how--logo
+          = icon('fas', 'credit-card')
+          = @default_card_information2.brand
 
--#     - if @cnt >=3
--#       %h3.purchase-method__how
--#         .purchase-method__how--name
--#           ③クレジットカード
--#           = link_to delete3_user_cards_path(current_user.id), method: "post", class:"blue" do
--#             削除
--#         .purchase-method__how--number
--#           = "**** **** **** " + "#{@default_card_information3.last4}"
--#         .purchase-method__how--exp
--#           = "有効期限"  + "#{@default_card_information3.exp_month}"+"/" "#{@default_card_information3.exp_year}"
--#         .purchase-method__how--logo
--#           = icon('fas', 'credit-card')
--#           = @default_card_information3.brand
+    - if @cnt >=3
+      %h3.purchase-method__how
+        .purchase-method__how--name
+          ③クレジットカード
+          = link_to delete3_user_cards_path(current_user.id), method: "post", class:"blue" do
+            削除
+        .purchase-method__how--number
+          = "**** **** **** " + "#{@default_card_information3.last4}"
+        .purchase-method__how--exp
+          = "有効期限"  + "#{@default_card_information3.exp_month}"+"/" "#{@default_card_information3.exp_year}"
+        .purchase-method__how--logo
+          = icon('fas', 'credit-card')
+          = @default_card_information3.brand
 
--#   %footer.sub-footer
--#     .sub-footer__logos
--#       = link_to root_path do
--#         = image_tag "/images/logo/logo.png", class: "sub-footer__logo"
--#     %p &copy FurimaApuri
+  %footer.sub-footer
+    .sub-footer__logos
+      = link_to root_path do
+        = image_tag "/images/logo/logo.png", class: "sub-footer__logo"
+    %p &copy FurimaApuri

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,60 +1,60 @@
--# %script{src: "https://js.pay.jp/", type: "text/javascript"}
+%script{src: "https://js.pay.jp/", type: "text/javascript"}
 
--# .mypage
--#   %main.mypage-contents.clearfix
--#     = render "users/mypage_side"
--#     .signup-main
--#       %section.mypage-content__chapter-container
--#         %h2.signup-main__chapter-head
--#           クレジットカード情報入力
--#         = form_with model: @card, url: "/products/#{@product.id}/cards", method: 'POST', id: 'charge-form', class: 'signup-main__inner--registration-form', novalidate: 'novalidate', html: { name: 'inputForm' } do |f|
--#           .signup-main__content
--#             .signup-main__form-group
--#               %label{ for: 'payment_card_no' } カード番号
--#               %span.signup-main__form-require 必須
--#               %input.signup-main__input-default{ type: 'text', id: 'card_number', placeholder: '半角数字のみ', maxlength: '19' }
--#               %ul.signup-main__has-error-text{ id: 'card-no-error-wrapper' }
--#               %ul.signup-main__card-list
--#                 %li
--#                   = image_tag '//pcweb-assets.mercdn.net/assets/img/card/visa.svg?2246739708', width: '49', height: '20' 
--#                 %li
--#                   = image_tag '//pcweb-assets.mercdn.net/assets/img/card/master-card.svg?2246739708', width: '34', height: '20'
--#                 %li
--#                   = image_tag '//pcweb-assets.mercdn.net/assets/img/card/saison-card.svg?2246739708', width: '30', height: '20'
--#                 %li
--#                   = image_tag '//pcweb-assets.mercdn.net/assets/img/card/jcb.svg?2246739708', width: '32', height: '20'
--#                 %li
--#                   = image_tag '//pcweb-assets.mercdn.net/assets/img/card/american_express.svg?2246739708', width: '21', height: '20'
--#                 %li
--#                   = image_tag '//pcweb-assets.mercdn.net/assets/img/card/dinersclub.svg?2246739708', width: '32', height: '20'
--#                 %li
--#                   = image_tag '//pcweb-assets.mercdn.net/assets/img/card/discover.svg?2246739708', width: '32', height: '20'
+.mypage
+  %main.mypage-contents.clearfix
+    = render "users/mypage_side"
+    .signup-main
+      %section.mypage-content__chapter-container
+        %h2.signup-main__chapter-head
+          クレジットカード情報入力
+        = form_with model: @card, url: "/products/#{@product.id}/cards", method: 'POST', id: 'charge-form', class: 'signup-main__inner--registration-form', novalidate: 'novalidate', html: { name: 'inputForm' } do |f|
+          .signup-main__content
+            .signup-main__form-group
+              %label{ for: 'payment_card_no' } カード番号
+              %span.signup-main__form-require 必須
+              %input.signup-main__input-default{ type: 'text', id: 'card_number', placeholder: '半角数字のみ', maxlength: '19' }
+              %ul.signup-main__has-error-text{ id: 'card-no-error-wrapper' }
+              %ul.signup-main__card-list
+                %li
+                  = image_tag '//pcweb-assets.mercdn.net/assets/img/card/visa.svg?2246739708', width: '49', height: '20' 
+                %li
+                  = image_tag '//pcweb-assets.mercdn.net/assets/img/card/master-card.svg?2246739708', width: '34', height: '20'
+                %li
+                  = image_tag '//pcweb-assets.mercdn.net/assets/img/card/saison-card.svg?2246739708', width: '30', height: '20'
+                %li
+                  = image_tag '//pcweb-assets.mercdn.net/assets/img/card/jcb.svg?2246739708', width: '32', height: '20'
+                %li
+                  = image_tag '//pcweb-assets.mercdn.net/assets/img/card/american_express.svg?2246739708', width: '21', height: '20'
+                %li
+                  = image_tag '//pcweb-assets.mercdn.net/assets/img/card/dinersclub.svg?2246739708', width: '32', height: '20'
+                %li
+                  = image_tag '//pcweb-assets.mercdn.net/assets/img/card/discover.svg?2246739708', width: '32', height: '20'
                 
                 
--#             .signup-main__form-group.signup-form-expire
--#               %label{ for: 'payment_card_expire'} 有効期限
--#               %span.signup-main__form-require 必須
--#               %br
--#               .signup-main__select-wrap--half
--#                 = f.select :exp_month, [["01",1],["02",2],["03",3],["04",4],["05",5],["06",6],["07",7],["08",8],["09",9],["10",10],["11",11],["12",12]],{} , class: 'form-signup__month__select', id:'exp_month'
--#                 %i.fas.fa-chevron-down
--#                 %span.month-year 月
--#               .signup-main__select-wrap--half
--#                 = f.select :exp_year, [["19",2019],["20",2020],["21",2021],["22",2022],["23",2023],["24",2024],["25",2025],["26",2026],["27",2027],["28",2028],["29",2029]],{} , class: 'form-signup__month__select', id:'exp_year'
--#                 = icon 'fas', 'chevron-down'
--#                 %span.month-year 年
--#               %ul.signup-main__has-error-text{ id: 'expire-mm-error-wrapper' }
--#               %ul.signup-main__has-error-text{ id: 'expire-yy-error-wrapper' }
+            .signup-main__form-group.signup-form-expire
+              %label{ for: 'payment_card_expire'} 有効期限
+              %span.signup-main__form-require 必須
+              %br
+              .signup-main__select-wrap--half
+                = f.select :exp_month, [["01",1],["02",2],["03",3],["04",4],["05",5],["06",6],["07",7],["08",8],["09",9],["10",10],["11",11],["12",12]],{} , class: 'form-signup__month__select', id:'exp_month'
+                %i.fas.fa-chevron-down
+                %span.month-year 月
+              .signup-main__select-wrap--half
+                = f.select :exp_year, [["19",2019],["20",2020],["21",2021],["22",2022],["23",2023],["24",2024],["25",2025],["26",2026],["27",2027],["28",2028],["29",2029]],{} , class: 'form-signup__month__select', id:'exp_year'
+                = icon 'fas', 'chevron-down'
+                %span.month-year 年
+              %ul.signup-main__has-error-text{ id: 'expire-mm-error-wrapper' }
+              %ul.signup-main__has-error-text{ id: 'expire-yy-error-wrapper' }
             
--#             .signup-main__form-group.seqcode
--#               %label{ for: 'payment_card_security_code'} セキュリティコード
--#               %span.signup-main__form-require 必須
--#               %input.signup-main__input-default{ type: 'text', id: 'cvc', placeholder: 'カード背面4桁もしくは3桁の番号' }
--#               %ul.signup-main__has-error-text{ id: 'security-code-error-wrapper' }
--#               .signup-main__seqcode
--#                 .signup-main__seqcode__text{ id: 'seqcode-tips-toggle' }
--#                   %span.signup-main__form-question?
--#                   カード背面の番号とは？
+            .signup-main__form-group.seqcode
+              %label{ for: 'payment_card_security_code'} セキュリティコード
+              %span.signup-main__form-require 必須
+              %input.signup-main__input-default{ type: 'text', id: 'cvc', placeholder: 'カード背面4桁もしくは3桁の番号' }
+              %ul.signup-main__has-error-text{ id: 'security-code-error-wrapper' }
+              .signup-main__seqcode
+                .signup-main__seqcode__text{ id: 'seqcode-tips-toggle' }
+                  %span.signup-main__form-question?
+                  カード背面の番号とは？
 
--#             #card_token
--#             = submit_tag "追加する" ,id: "token_submit", class: "top__margin"
+            #card_token
+            = submit_tag "追加する" ,id: "token_submit", class: "top__margin"

--- a/app/views/cards/pay.html.haml
+++ b/app/views/cards/pay.html.haml
@@ -1,9 +1,9 @@
--# = render "partial/header"
--# .new-wrapper
--#   .new-wrapper__main
--#     .new-wrapper__main--create
--#       商品の購入が完了しました
--#       %br
--#     = link_to root_path,class: "back-home" do
--#       トップページに戻る
--# = render "partial/footer"
+= render "partial/header"
+.new-wrapper
+  .new-wrapper__main
+    .new-wrapper__main--create
+      商品の購入が完了しました
+      %br
+    = link_to root_path,class: "back-home" do
+      トップページに戻る
+= render "partial/footer"

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,74 +1,74 @@
--# %body.post-template
+%body.post-template
 
--#   %header.purchase-confirm
--#     =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "header-icon" 
+  %header.purchase-confirm
+    =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "header-icon" 
 
--#   .wrapper-purchase-confirm
--#     %h2.title
--#       購入内容の確認
+  .wrapper-purchase-confirm
+    %h2.title
+      購入内容の確認
     
--#     %section.product-info
--#       %img.product-info__photo{:src => "https://static.mercdn.net/item/detail/orig/photos/m62908304477_1.jpg?1588653656"}/
--#       .product-info__name
--#         =@product.name
+    %section.product-info
+      %img.product-info__photo{:src => "https://static.mercdn.net/item/detail/orig/photos/m62908304477_1.jpg?1588653656"}/
+      .product-info__name
+        =@product.name
 
--#     %section.product-info-sub
--#       .product-info-sub__price
--#         ="¥"+ "#{@product.price}"
--#       .main-content-sub__tax 
--#         (税込)
--#       .main-content-sub__shipFee 
--#         送料込み
+    %section.product-info-sub
+      .product-info-sub__price
+        ="¥"+ "#{@product.price}"
+      .main-content-sub__tax 
+        (税込)
+      .main-content-sub__shipFee 
+        送料込み
 
--#     %section.product-price
--#       .product-price__title
--#         支払い金額
--#       .product-price__amount
--#         ="¥"+ "#{@product.price}"
+    %section.product-price
+      .product-price__title
+        支払い金額
+      .product-price__amount
+        ="¥"+ "#{@product.price}"
 
--#     %section.purchase-method
--#       .purchase-method__titile
--#         支払い方法
--#         - if Card.where(user: current_user).exists?
--#           =link_to "変更する", new_product_card_path(@product.id), method: :get , class: "change"
+    %section.purchase-method
+      .purchase-method__titile
+        支払い方法
+        - if Card.where(user: current_user).exists?
+          =link_to "変更する", new_product_card_path(@product.id), method: :get , class: "change"
         
--#           .purchase-method__how
--#             .purchase-method__how--name
--#               クレジットカード
--#             .purchase-method__how--number
--#               = "**** **** **** " + "#{@default_card_information.last4}"
--#             .purchase-method__how--exp
--#               = "有効期限"  + "#{@default_card_information.exp_month}"+"/" "#{@default_card_information.exp_year}"
--#             .purchase-method__how--logo
--#               = icon('fas', 'credit-card')
--#               = @default_card_information.brand
--#         - else
--#           =link_to "新規登録", new_product_card_path(@product.id), method: :get , class: "change"
+          .purchase-method__how
+            .purchase-method__how--name
+              クレジットカード
+            .purchase-method__how--number
+              = "**** **** **** " + "#{@default_card_information.last4}"
+            .purchase-method__how--exp
+              = "有効期限"  + "#{@default_card_information.exp_month}"+"/" "#{@default_card_information.exp_year}"
+            .purchase-method__how--logo
+              = icon('fas', 'credit-card')
+              = @default_card_information.brand
+        - else
+          =link_to "新規登録", new_product_card_path(@product.id), method: :get , class: "change"
 
--#     %section.purchase-shipping
--#       .purchase-shipping__title
--#         配送先
--#         =link_to "変更する", new_product_path, method: :get , class: "change"
+    %section.purchase-shipping
+      .purchase-shipping__title
+        配送先
+        =link_to "変更する", new_product_path, method: :get , class: "change"
 
--#       .purchase-shipping__where
--#         .purchase-shipping__where--pcode
--#           〒321-0634
--#         .purchase-shipping__where--address
--#           栃木県 那須烏山市 野上988-1 プラシードC 101号
--#         .purchase-shipping__where--name
--#           Robby Naish
+      .purchase-shipping__where
+        .purchase-shipping__where--pcode
+          〒321-0634
+        .purchase-shipping__where--address
+          栃木県 那須烏山市 野上988-1 プラシードC 101号
+        .purchase-shipping__where--name
+          Robby Naish
 
--#     .purchase-btn
--#       - if Card.where(user: current_user).exists?
--#         =link_to "購入する", pay_product_cards_path(@product.id), method: :post , class: "purchase"
--#       - else
--#         決済方法を登録してください
+    .purchase-btn
+      - if Card.where(user: current_user).exists?
+        =link_to "購入する", pay_product_cards_path(@product.id), method: :post , class: "purchase"
+      - else
+        決済方法を登録してください
 
--#   %footer.purchase-confirma
--#     .purchase-confirm__rule
--#       プライバシーポリシー FURIMA利用規約
--#       %br
--#         特定商取引に関する表記
--#       =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "footer-icon" 
+  %footer.purchase-confirma
+    .purchase-confirm__rule
+      プライバシーポリシー FURIMA利用規約
+      %br
+        特定商取引に関する表記
+      =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "footer-icon" 
 
       


### PR DESCRIPTION
＃What
PayJPを用いたクレジットカード購入機能の実装
具体的実装内容は下記３点である。

動画１_クレジットカードの登録
https://gyazo.com/627b535c20f194a62819c4eaf22211ee

動画２_商品の購入
https://gyazo.com/2e7694b6ff2cd1262d862fdf90b02cae

動画３_登録カードの一覧表示と削除
https://gyazo.com/e70a410ba662002646b659615b237f71

＃Why
オンライン上での売買にはクレジットカードを使った決済が一般的であり、ユーザーの利便性を考慮するとこの機能は必須であるため。
