### PR TITLE
商品購入確認ページの微修正

### DIFF
--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,78 +1,78 @@
--# %body.post-template
+%body.post-template
 
--#   %header.purchase-confirm
--#     =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "header-icon" 
+  %header.purchase-confirm
+    =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "header-icon" 
 
--#   .wrapper-purchase-confirm
--#     %h2.title
--#       購入内容の確認
+  .wrapper-purchase-confirm
+    %h2.title
+      購入内容の確認
     
--#     %section.product-info
--#       = image_tag @product.product_photos[0].photo.url, class:"item-main-content__photo--big"
--#       .product-info__name
--#         =@product.name
+    %section.product-info
+      = image_tag @product.product_photos[0].photo.url, class:"item-main-content__photo--big"
+      .product-info__name
+        =@product.name
 
--#     %section.product-info-sub
--#       .product-info-sub__price
--#         ="¥"+ "#{@product.price}"
--#       .main-content-sub__tax 
--#         (税込)
--#       .main-content-sub__shipFee 
--#         = @product.bear
+    %section.product-info-sub
+      .product-info-sub__price
+        ="¥"+ "#{@product.price}"
+      .main-content-sub__tax 
+        (税込)
+      .main-content-sub__shipFee 
+        = @product.bear
 
--#     %section.product-price
--#       .product-price__title
--#         支払い金額
--#       .product-price__amount
--#         ="¥"+ "#{@product.price}"
+    %section.product-price
+      .product-price__title
+        支払い金額
+      .product-price__amount
+        ="¥"+ "#{@product.price}"
 
--#     %section.purchase-method
--#       .purchase-method__titile
--#         支払い方法
--#         - if Card.where(user: current_user).exists?
--#           =link_to "変更する", new_product_card_path(@product.id), method: :get , class: "change"
+    %section.purchase-method
+      .purchase-method__titile
+        支払い方法
+        - if Card.where(user: current_user).exists?
+          =link_to "変更する", new_product_card_path(@product.id), method: :get , class: "change"
         
--#           .purchase-method__how
--#             .purchase-method__how--name
--#               クレジットカード
--#             .purchase-method__how--number
--#               = "**** **** **** " + "#{@default_card_information.last4}"
--#             .purchase-method__how--exp
--#               = "有効期限"  + "#{@default_card_information.exp_month}"+"/" "#{@default_card_information.exp_year}"
--#             .purchase-method__how--logo
--#               = icon('fas', 'credit-card')
--#               = @default_card_information.brand
--#         - else
--#           =link_to "新規登録", new_product_card_path(@product.id), method: :get , class: "change"
+          .purchase-method__how
+            .purchase-method__how--name
+              クレジットカード
+            .purchase-method__how--number
+              = "**** **** **** " + "#{@default_card_information.last4}"
+            .purchase-method__how--exp
+              = "有効期限"  + "#{@default_card_information.exp_month}"+"/" "#{@default_card_information.exp_year}"
+            .purchase-method__how--logo
+              = icon('fas', 'credit-card')
+              = @default_card_information.brand
+        - else
+          =link_to "新規登録", new_product_card_path(@product.id), method: :get , class: "change"
 
--#     %section.purchase-shipping
--#       .purchase-shipping__title
--#         配送先
--#         =link_to "変更する", new_product_path, method: :get , class: "change"
+    %section.purchase-shipping
+      .purchase-shipping__title
+        配送先
+        =link_to "変更する", new_product_path, method: :get , class: "change"
 
--#       .purchase-shipping__where
--#         .purchase-shipping__where--pcode
--#           = "〒" + "#{@user.address.postal_code}"
--#         .purchase-shipping__where--address
--#           = @user.address.prefecture.name
--#           = @user.address.city
--#           = @user.address.other
--#           = @user.address.building_name
+      .purchase-shipping__where
+        .purchase-shipping__where--pcode
+          = "〒" + "#{@user.address.postal_code}"
+        .purchase-shipping__where--address
+          = @user.address.prefecture.name
+          = @user.address.city
+          = @user.address.other
+          = @user.address.building_name
 
--#         .purchase-shipping__where--name
--#           = @user.nickname
+        .purchase-shipping__where--name
+          = @user.nickname
 
--#     .purchase-btn
--#       - if Card.where(user: current_user).exists?
--#         =link_to "購入する", pay_product_cards_path(@product.id), method: :post , class: "purchase"
--#       - else
--#         決済方法を登録してください
+    .purchase-btn
+      - if Card.where(user: current_user).exists?
+        =link_to "購入する", pay_product_cards_path(@product.id), method: :post , class: "purchase"
+      - else
+        決済方法を登録してください
 
--#   %footer.purchase-confirma
--#     .purchase-confirm__rule
--#       プライバシーポリシー FURIMA利用規約
--#       %br
--#         特定商取引に関する表記
--#       =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "footer-icon" 
+  %footer.purchase-confirma
+    .purchase-confirm__rule
+      プライバシーポリシー FURIMA利用規約
+      %br
+        特定商取引に関する表記
+      =link_to image_tag(src="logo/logo.png", height: "50", width: "auto"), "/", class: "footer-icon" 
 
     


### PR DESCRIPTION
＃What
商品購入確認ページの微修正（仕上げ）
・商品購入確認ページに商品情報と、購入者の情報（住所、カード情報）が表示される
・クレジットカードを登録しないと、購入ボタンが表示されない

＃Why
買い手がなんの製品を購入しようとしているか、決済方法は何か、どこに送付されるのかを確認出来る様に一度購入確認ページを挟むことで、スムーズで確かな取引を行っていただくため、
※メンバーのコードレビュー済です。

クレカ登録前の画面
![image](https://user-images.githubusercontent.com/63226783/82409528-f4c5ac00-9aa8-11ea-8c20-bd8096326653.png)

クレカ登録後の画面
https://gyazo.com/903fa3ac2a8f73917b9fe70dd8a89a26
