### PR TITLE
カテゴリー表示　修正

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -73,6 +73,8 @@
   }
   &__left-nav{
     display: flex;
+    z-index: 2;
+    
     &--category{
       position: absolute;
     }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
     last_name              {"山田"}
     last_name_furigana     {"やまだ"}
     birthday               {"19900925"}
+  end
+  
     
 
   end


### PR DESCRIPTION
# What
マイページでカテゴリー表示をする際、javascriptで表示させているビューが下に潜りこむので
z-indexをscssにて加筆

# Why
意図しない表示となっていたため