### PR TITLE
クレジットカード登録画面の編集

### DIFF
--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -2,13 +2,31 @@
 * {
   box-sizing: border-box;
 }
-
+.card-index.buypage {
+  width: 100%;
+  height: 900px;
+}
 .mypage {
   width: 100%;
   height: 100%;
   background-color: #f5f5f5;
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
 
+  .mypage-contents.clearfix.buypage {
+    width: 750px;
+    height: 600px;
+    margin: 40px auto 0;
+    border-style: solid;
+    border-width: 0;
+    display: block;
+    padding: 0 0 40px 0;
+    .signup-main.buypage {
+      width: 700px;
+      margin: 0 auto;
+      
+      
+    }
+  }
   .mypage-contents.clearfix {
     width: 1020px;
     height: 1301px;
@@ -28,7 +46,7 @@
         width: 700px;
         height: 562px;
         background-color: #fff;
-        margin-top: 40px;
+       
         .signup-main__chapter-head {
           width: 700px;
           height: 50px;

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -5,6 +5,7 @@ class CardsController < ApplicationController
   before_action :set_product, only: [:create, :show, :pay, :new]
   before_action :set_cards, only: [:delete, :index, :show, :new]
   before_action :set_create, only: [:create, :create1]
+  before_action :set_parents, only: :new1
 
   def set_cards
     @card = Card.find_by(user_id: current_user.id)
@@ -104,10 +105,16 @@ class CardsController < ApplicationController
     redirect_to  user_cards_path(current_user.id)
   end
 
+  def new1
+  end
+
   private
 
   def get_payjp_info
     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_PRIVATE_KEY)
   end
 
+  def set_parents
+    @parents = Category.where(ancestry: nil) 
+  end
 end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -5,6 +5,7 @@ class CardsController < ApplicationController
   before_action :set_product, only: [:create, :show, :pay, :new]
   before_action :set_cards, only: [:delete, :index, :show, :new]
   before_action :set_create, only: [:create, :create1]
+  before_action :set_parents, only: :index
 
   def set_cards
     @card = Card.find_by(user_id: current_user.id)
@@ -23,7 +24,7 @@ class CardsController < ApplicationController
           @cardinfo = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
         elsif @cnt == 3
           @default_card_information3 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
-          @cardinfo　= Payjp::Customer.retrieve(card.customer_id).cards.data[0]
+          @cardinfo = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
         end
       end
     end
@@ -36,6 +37,9 @@ class CardsController < ApplicationController
   def show
     @user = User.find(current_user.id)
 
+  end
+
+  def index
   end
 
   def pay
@@ -110,4 +114,7 @@ class CardsController < ApplicationController
     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_PRIVATE_KEY)
   end
 
+  def set_parents
+    @parents = Category.where(ancestry: nil) 
+  end
 end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -5,7 +5,6 @@ class CardsController < ApplicationController
   before_action :set_product, only: [:create, :show, :pay, :new]
   before_action :set_cards, only: [:delete, :index, :show, :new]
   before_action :set_create, only: [:create, :create1]
-  before_action :set_parents, only: :index
 
   def set_cards
     @card = Card.find_by(user_id: current_user.id)
@@ -24,7 +23,7 @@ class CardsController < ApplicationController
           @cardinfo = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
         elsif @cnt == 3
           @default_card_information3 = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
-          @cardinfo = Payjp::Customer.retrieve(card.customer_id).cards.data[0]
+          @cardinfo　= Payjp::Customer.retrieve(card.customer_id).cards.data[0]
         end
       end
     end
@@ -37,9 +36,6 @@ class CardsController < ApplicationController
   def show
     @user = User.find(current_user.id)
 
-  end
-
-  def index
   end
 
   def pay
@@ -114,7 +110,4 @@ class CardsController < ApplicationController
     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_PRIVATE_KEY)
   end
 
-  def set_parents
-    @parents = Category.where(ancestry: nil) 
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_parents, only: [:show, :destroy]
+  before_action :set_parents
 
   def show
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_parents
+  before_action :set_parents, only: [:show, :destroy]
 
   def show
   end

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,12 +1,15 @@
 %script{src: "https://js.pay.jp/", type: "text/javascript"}
-
+%body.card-index.buypage
 .mypage
-  %main.mypage-contents.clearfix
-    = render "users/mypage_side"
-    .signup-main
+  %h1.sub-header
+    = link_to root_path do
+      = image_tag "/images/logo/logo.png", class: "sub-header__logo"
+  %main.mypage-contents.clearfix.buypage
+    
+    .signup-main.buypage
       %section.mypage-content__chapter-container
         %h2.signup-main__chapter-head
-          クレジットカード情報入力
+          支払い方法
         = form_with model: @card, url: "/products/#{@product.id}/cards", method: 'POST', id: 'charge-form', class: 'signup-main__inner--registration-form', novalidate: 'novalidate', html: { name: 'inputForm' } do |f|
           .signup-main__content
             .signup-main__form-group
@@ -57,4 +60,9 @@
                   カード背面の番号とは？
 
             #card_token
-            = submit_tag "追加する" ,id: "token_submit", class: "top__margin"
+            = submit_tag "登録する" ,id: "token_submit", class: "top__margin"
+  %footer.sub-footer
+    .sub-footer__logos
+      = link_to root_path do
+        = image_tag "/images/logo/logo.png", class: "sub-footer__logo"
+    %p &copy FurimaApuri

--- a/app/views/cards/new1.html.haml
+++ b/app/views/cards/new1.html.haml
@@ -1,5 +1,5 @@
 %script{src: "https://js.pay.jp/", type: "text/javascript"}
-
+= render "/partial/header"
 .mypage
   %main.mypage-contents.clearfix
     = render "users/mypage_side"
@@ -58,3 +58,17 @@
 
             #card_token
             = submit_tag "追加する" ,id: "token_submit", class: "top__margin"
+%aside.appBanner
+  .inner
+    %h2.inner__title
+      だれでもかんたん、人生を変えるフリマアプリ
+    %p.inner__text 今すぐ無料ダウンロード
+    .inner__icon
+      = link_to '#', class: 'Btn' do
+        = image_tag "/images/logo/download-on-app-store.png",class:'app'
+      = link_to '#', class: 'Btn' do
+        = image_tag "/images/logo/btn_googleplay.png",class:'app'
+
+
+= render "/partial/footer"
+            

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   end
 
   root to: "products#index"
-  resources :cards, only: :new
+  resources :cards, only: [:new, :new1]
 
   resources :users, only: [:show, :destroy] do
     collection do


### PR DESCRIPTION
# What
### 購入ページからカード新規登録画面へ遷移したページの修正
　サイドバーがついていたのをなくし、コンテンツが中央にくるようにした。
　フォーム名を　クレジットカード情報入力→支払い方法　に変更
　ボタンを　追加する→登録する　に変更
https://i.gyazo.com/bf8602fc9d85c02a8d03511a0135cc29.mp4

### マイページからのカード登録画面の修正。
　ヘッダーとフッターを追加。コンテンツ位置の微調整。
https://i.gyazo.com/5e4eabdb719e182ace72a23a9e8298bc.mp4

# Why
よりメルカリなどの見本の見た目にするため。